### PR TITLE
feat: Add PostgreSQL database in Docker for backend

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -15,3 +15,14 @@ Este proyecto está construido con Java y Spring Boot.
 2. Navega a la carpeta `backend` en tu terminal.
 3. Ejecuta el comando `./gradlew bootRun`.
 4. El servidor backend se iniciará en el puerto predeterminado (generalmente 8080).
+
+## Database Setup
+
+This project uses a PostgreSQL database running in a Docker container.
+
+To start the database:
+1. Make sure you have Docker and Docker Compose installed.
+2. Navigate to the `backend` directory in your terminal.
+3. Run the command: `docker-compose up -d`
+
+This will start the PostgreSQL container in detached mode. The database will be accessible on `localhost:5432` with the username `myuser`, password `mypassword`, and database name `mydatabase`, as configured in `docker-compose.yml` and `application.properties`.

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:latest
+    container_name: my_postgres_db
+    environment:
+      POSTGRES_USER: myuser
+      POSTGRES_PASSWORD: mypassword
+      POSTGRES_DB: mydatabase
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,8 +1,9 @@
-# Database Configuration (H2 for in-memory testing - simplified)
-spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
-spring.datasource.username=sa
-spring.datasource.password=
-spring.jpa.hibernate.ddl-auto=create-drop
+# Database Configuration (PostgreSQL)
+spring.datasource.url=jdbc:postgresql://localhost:5432/mydatabase
+spring.datasource.username=myuser
+spring.datasource.password=mypassword
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.hibernate.ddl-auto=update
 
 # JPA Show SQL
 spring.jpa.show-sql=true


### PR DESCRIPTION
Integrates a PostgreSQL database using Docker Compose for the backend application.

Key changes:
- Added a `docker-compose.yml` file in the `backend` directory to define the PostgreSQL service. This includes image configuration, environment variables for credentials, port mapping, and volume for data persistence.
- Updated `backend/src/main/resources/application.properties` to connect to the PostgreSQL database. This includes changing the datasource URL, username, password, driver class, and setting `spring.jpa.hibernate.ddl-auto` to `update`.
- Updated `backend/README.md` with instructions on how to set up and run the PostgreSQL database using Docker Compose.

This change allows for a more robust and persistent database solution for the backend, replacing the previous in-memory H2 database configuration for development and production environments.